### PR TITLE
Server clustering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 .eunit
 .rebar
+.rebar3
 .coap_dialyzer*
 
+.fetch
 .project
 .settings
 deps

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# Note
+
+This a fork of the original gen_coap which was modified to support clustering,
+i.e multiple udp sockets launched are different servers now (each with its own
+state) and requests coming to them can be differentiated by an additional
+parameter (listening port number) provided to the callbacks.
+
+Moreover it is possible now to provide a specific outgoing UDP port number in
+client.
+
+The original `README.md` follows, but it might be out-of-date.
+
 # Generic Erlang CoAP Client/Server
 
 Pure Erlang implementation of the Constrained Application Protocol (CoAP),

--- a/examples/src/sample_server.erl
+++ b/examples/src/sample_server.erl
@@ -67,7 +67,7 @@ start() ->
     {atomic, ok} = mnesia:create_table(resources, []),
     {ok, _} = application:ensure_all_started(gen_coap),
     {ok, _} = coap_server:start_udp(coap_udp_socket),
-    {ok, _} = coap_server:start_dtls(coap_dtls_socket, [{certfile, "cert.pem"}, {keyfile, "key.pem"}]),
+    % {ok, _} = coap_server:start_dtls(coap_dtls_socket, [{certfile, "cert.pem"}, {keyfile, "key.pem"}]),
     coap_server_registry:add_handler([], ?MODULE, undefined).
 
 % end of file

--- a/examples/src/sample_server.erl
+++ b/examples/src/sample_server.erl
@@ -4,7 +4,7 @@
 -behaviour(coap_resource).
 
 -export([coap_discover/2,
-         coap_get/5,
+         coap_get/6,
          coap_post/5,
          coap_put/5,
          coap_delete/4,
@@ -20,12 +20,12 @@ coap_discover(Prefix, _Args) ->
     io:format("discover ~p~n", [Prefix]),
     [{absolute, Prefix++Name, []} || Name <- mnesia:dirty_all_keys(resources)].
 
-coap_get(_ChId, Prefix, [<<"oic">>, <<"res">>] = Name, Query, _Request) ->
-    io:format("get ~p ~p ~p~n", [Prefix, Name, Query]),
+coap_get(_ChId, Port, Prefix, [<<"oic">>, <<"res">>] = Name, Query, _Request) ->
+    io:format("get ~p ~p ~p ~p~n", [Port, Prefix, Name, Query]),
     #coap_content{etag = <<"1234">>,
                   format = <<"text/plain">>};
-coap_get(_ChId, Prefix, Name, Query, _Request) ->
-    io:format("get ~p ~p ~p~n", [Prefix, Name, Query]),
+coap_get(_ChId, Port, Prefix, Name, Query, _Request) ->
+    io:format("get ~p ~p ~p ~p~n", [Port, Prefix, Name, Query]),
     case mnesia:dirty_read(resources, Name) of
         [{resources, Name, Resource}] -> Resource;
         [] -> {error, not_found}

--- a/examples/src/sample_server.erl
+++ b/examples/src/sample_server.erl
@@ -5,11 +5,11 @@
 
 -export([coap_discover/2,
          coap_get/6,
-         coap_post/5,
-         coap_put/5,
-         coap_delete/4,
-         coap_observe/5,
-         coap_unobserve/1,
+         coap_post/6,
+         coap_put/6,
+         coap_delete/5,
+         coap_observe/6,
+         coap_unobserve/2,
          handle_info/2,
          coap_ack/2]).
 
@@ -31,31 +31,31 @@ coap_get(_ChId, Port, Prefix, Name, Query, _Request) ->
         [] -> {error, not_found}
     end.
 
-coap_post(_ChId, _Prefix, [<<"stop">>], _Content, _Request) ->
+coap_post(_ChId, _Port, _Prefix, [<<"stop">>], _Content, _Request) ->
     main ! stop,
     {ok, content, #coap_content{}};
-coap_post(_ChId, Prefix, Name, Content, _Request) ->
-    io:format("post ~p ~p ~p~n", [Prefix, Name, Content]),
+coap_post(_ChId, Port, Prefix, Name, Content, _Request) ->
+    io:format("post ~p ~p ~p ~p~n", [Port, Prefix, Name, Content]),
     {error, method_not_allowed}.
 
-coap_put(_ChId, Prefix, Name, Content, _Request) ->
-    io:format("put ~p ~p ~p~n", [Prefix, Name, Content]),
+coap_put(_ChId, Port, Prefix, Name, Content, _Request) ->
+    io:format("put ~p ~p ~p ~p~n", [Port, Prefix, Name, Content]),
     mnesia:dirty_write(resources, {resources, Name, Content}),
     coap_responder:notify(Prefix++Name, Content),
     ok.
 
-coap_delete(_ChId, Prefix, Name, _Request) ->
-    io:format("delete ~p ~p~n", [Prefix, Name]),
+coap_delete(_ChId, Port, Prefix, Name, _Request) ->
+    io:format("delete ~p ~p ~p~n", [Port, Prefix, Name]),
     mnesia:dirty_delete(resources, Name),
     coap_responder:notify(Prefix++Name, {error, not_found}),
     ok.
 
-coap_observe(_ChId, Prefix, Name, _Ack, _Request) ->
-    io:format("observe ~p ~p~n", [Prefix, Name]),
+coap_observe(_ChId, Port, Prefix, Name, _Ack, _Request) ->
+    io:format("observe ~p ~p ~p~n", [Port, Prefix, Name]),
     {ok, {state, Prefix, Name}}.
 
-coap_unobserve({state, Prefix, Name}) ->
-    io:format("unobserve ~p ~p~n", [Prefix, Name]),
+coap_unobserve(Port, {state, Prefix, Name}) ->
+    io:format("unobserve ~p ~p ~p~n", [Port, Prefix, Name]),
     ok.
 
 handle_info(_Message, State) -> {noreply, State}.

--- a/src/coap_channel.erl
+++ b/src/coap_channel.erl
@@ -48,7 +48,7 @@ send_response(Channel, Ref, Message) ->
 close(Pid) ->
     gen_server:cast(Pid, shutdown).
 
-init([SupPid, SockPid, ChId, ReSup]) ->
+init([SupPid, SockPid, {ListenPort, ChId}, ReSup]) ->
     % we want to get called upon termination
     process_flag(trap_exit, true),
     {ok, #state{sup=SupPid, sock=SockPid, cid=ChId, tokens=dict:new(),
@@ -99,22 +99,22 @@ transport_response(Message=#coap_message{id=MsgId}, Receiver, State=#state{trans
     end.
 
 % incoming CON(0) or NON(1) request
-handle_info({datagram, BinMessage= <<?VERSION:2, 0:1, _:1, _TKL:4, 0:3, _CodeDetail:5, MsgId:16, _/bytes>>}, State) ->
+handle_info({datagram, {ListenPort, BinMessage= <<?VERSION:2, 0:1, _:1, _TKL:4, 0:3, _CodeDetail:5, MsgId:16, _/bytes>>}}, State) ->
     TrId = {in, MsgId},
     update_state(State, TrId,
-        coap_transport:received(BinMessage, create_transport(TrId, undefined, State)));
+        coap_transport:received(ListenPort, BinMessage, create_transport(TrId, undefined, State)));
 % incoming CON(0) or NON(1) response
-handle_info({datagram, BinMessage= <<?VERSION:2, 0:1, _:1, TKL:4, _Code:8, MsgId:16, Token:TKL/bytes, _/bytes>>},
+handle_info({datagram, {ListenPort, BinMessage= <<?VERSION:2, 0:1, _:1, TKL:4, _Code:8, MsgId:16, Token:TKL/bytes, _/bytes>>}},
         State=#state{sock=Sock, cid=ChId, tokens=Tokens, trans=Trans}) ->
     TrId = {in, MsgId},
     case dict:find(TrId, Trans) of
         {ok, TrState} ->
-            update_state(State, TrId, coap_transport:received(BinMessage, TrState));
+            update_state(State, TrId, coap_transport:received(ListenPort, BinMessage, TrState));
         error ->
             case dict:find(Token, Tokens) of
                 {ok, Receiver} ->
                     update_state(State, TrId,
-                        coap_transport:received(BinMessage, init_transport(TrId, Receiver, State)));
+                        coap_transport:received(ListenPort, BinMessage, init_transport(TrId, Receiver, State)));
                 error ->
                     % token was not recognized
                     BinReset = coap_message_parser:encode(#coap_message{type=reset, id=MsgId}),
@@ -123,16 +123,16 @@ handle_info({datagram, BinMessage= <<?VERSION:2, 0:1, _:1, TKL:4, _Code:8, MsgId
             end
     end;
 % incoming ACK(2) or RST(3) to a request or response
-handle_info({datagram, BinMessage= <<?VERSION:2, _:2, _TKL:4, _Code:8, MsgId:16, _/bytes>>},
+handle_info({datagram, {ListenPort, BinMessage= <<?VERSION:2, _:2, _TKL:4, _Code:8, MsgId:16, _/bytes>>}},
         State=#state{trans=Trans}) ->
     TrId = {out, MsgId},
     update_state(State, TrId,
         case dict:find(TrId, Trans) of
             error -> undefined; % ignore unexpected responses
-            {ok, TrState} -> coap_transport:received(BinMessage, TrState)
+            {ok, TrState} -> coap_transport:received(ListenPort, BinMessage, TrState)
         end);
 % silently ignore other versions
-handle_info({datagram, <<Ver:2, _:6, _/bytes>> = Data}, State) when Ver /= ?VERSION ->
+handle_info({datagram, {ListenPort, <<Ver:2, _:6, _/bytes>> = Data}}, State) when Ver /= ?VERSION ->
     io:fwrite("ignoring CoAP version ~p datagram ~p~n", [Ver, Data]),
     {noreply, State};
 handle_info({timeout, TrId, Event}, State=#state{trans=Trans}) ->

--- a/src/coap_channel_sup_sup.erl
+++ b/src/coap_channel_sup_sup.erl
@@ -24,7 +24,10 @@ start_channel(SupPid, ChId) ->
             temporary, infinity, supervisor, []}).
 
 delete_channel(SupPid, ChId) ->
-    supervisor:terminate_child(SupPid, ChId).
+    case supervisor:terminate_child(SupPid, ChId) of
+        ok -> supervisor:delete_child(SupPid, ChId);
+        Error -> Error
+    end.
 
 init([]) ->
     {ok, {{one_for_one, 0, 1}, []}}.

--- a/src/coap_resource.erl
+++ b/src/coap_resource.erl
@@ -16,7 +16,7 @@
     [coap_uri()].
 
 % GET handler
--callback coap_get(coap_channel_id(), [binary()], [binary()], [binary()], coap_message:t()) ->
+-callback coap_get(coap_channel_id(), inet:port_number(), [binary()], [binary()], [binary()], coap_message:t()) ->
     coap_message:content() | {'error', atom()}.
 % POST handler
 -callback coap_post(coap_channel_id(), [binary()], [binary()], coap_message:content(), coap_message:t()) ->

--- a/src/coap_resource.erl
+++ b/src/coap_resource.erl
@@ -19,20 +19,20 @@
 -callback coap_get(coap_channel_id(), inet:port_number(), [binary()], [binary()], [binary()], coap_message:t()) ->
     coap_message:content() | {'error', atom()}.
 % POST handler
--callback coap_post(coap_channel_id(), [binary()], [binary()], coap_message:content(), coap_message:t()) ->
+-callback coap_post(coap_channel_id(), inet:port_number(), [binary()], [binary()], coap_message:content(), coap_message:t()) ->
     {'ok', atom(), coap_message:content()} | {'error', atom()}.
 % PUT handler
--callback coap_put(coap_channel_id(), [binary()], [binary()], coap_message:content(), coap_message:t()) ->
+-callback coap_put(coap_channel_id(), inet:port_number(), [binary()], [binary()], coap_message:content(), coap_message:t()) ->
     'ok' | {'error', atom()}.
 % DELETE handler
--callback coap_delete(coap_channel_id(), [binary()], [binary()], coap_message:t()) ->
+-callback coap_delete(coap_channel_id(), inet:port_number(), [binary()], [binary()], coap_message:t()) ->
     'ok' | {'error', atom()}.
 
 % observe request handler
--callback coap_observe(coap_channel_id(), [binary()], [binary()], boolean(), coap_message:t()) ->
+-callback coap_observe(coap_channel_id(), inet:port_number(), [binary()], [binary()], boolean(), coap_message:t()) ->
     {'ok', any()} | {'error', atom()}.
 % cancellation request handler
--callback coap_unobserve(any()) ->
+-callback coap_unobserve(inet:port_number(), any()) ->
     'ok'.
 % handler for messages sent to the responder process
 % used to generate notifications

--- a/src/coap_responder_sup.erl
+++ b/src/coap_responder_sup.erl
@@ -10,26 +10,26 @@
 -module(coap_responder_sup).
 -behaviour(supervisor).
 
--export([start_link/0, get_responder/2, init/1]).
+-export([start_link/0, get_responder/3, init/1]).
 
 -include("coap.hrl").
 
 start_link() ->
     supervisor:start_link(?MODULE, []).
 
-get_responder(SupPid, Request) ->
-    case start_responder(SupPid, Request) of
+get_responder(SupPid, Request, ListenPort) ->
+    case start_responder(SupPid, Request, ListenPort) of
         {ok, Pid} -> {ok, Pid};
         {error, {already_started, Pid}} -> {ok, Pid};
         {error, Other} -> {error, Other}
     end.
 
-start_responder(SupPid, #coap_message{method=Method, options=Options}) ->
+start_responder(SupPid, #coap_message{method=Method, options=Options}, ListenPort) ->
     Uri = proplists:get_value(uri_path, Options, []),
     Query = proplists:get_value(uri_query, Options, []),
     supervisor:start_child(SupPid,
         {{Method, Uri, Query},
-            {coap_responder, start_link, [self(), Uri]},
+            {coap_responder, start_link, [self(), Uri, ListenPort]},
             temporary, 5000, worker, []}).
 
 init([]) ->

--- a/src/coap_server_content.erl
+++ b/src/coap_server_content.erl
@@ -11,7 +11,7 @@
 -module(coap_server_content).
 -behaviour(coap_resource).
 
--export([coap_discover/2, coap_get/5, coap_post/5, coap_put/5, coap_delete/4,
+-export([coap_discover/2, coap_get/6, coap_post/5, coap_put/5, coap_delete/4,
     coap_observe/5, coap_unobserve/1, handle_info/2, coap_ack/2]).
 
 -include("coap.hrl").
@@ -19,12 +19,12 @@
 coap_discover(_Prefix, _Args) ->
     [].
 
-coap_get(_ChId, _Prefix, [], Query, _Request) ->
+coap_get(_ChId, _Port, _Prefix, [], Query, _Request) ->
     Links = core_link:encode(filter(coap_server_registry:get_links(), Query)),
     #coap_content{etag = binary:part(crypto:hash(sha, Links), {0,4}),
                   format = <<"application/link-format">>,
                   payload = list_to_binary(Links)};
-coap_get(_ChId, _Prefix, _Else, _Query, _Request) ->
+coap_get(_ChId, _Port,  _Prefix, _Else, _Query, _Request) ->
     {error, not_found}.
 
 coap_post(_ChId, _Prefix, _Suffix, _Content, _Request) -> {error, method_not_allowed}.

--- a/src/coap_server_content.erl
+++ b/src/coap_server_content.erl
@@ -11,8 +11,8 @@
 -module(coap_server_content).
 -behaviour(coap_resource).
 
--export([coap_discover/2, coap_get/6, coap_post/5, coap_put/5, coap_delete/4,
-    coap_observe/5, coap_unobserve/1, handle_info/2, coap_ack/2]).
+-export([coap_discover/2, coap_get/6, coap_post/6, coap_put/6, coap_delete/5,
+    coap_observe/6, coap_unobserve/2, handle_info/2, coap_ack/2]).
 
 -include("coap.hrl").
 
@@ -27,12 +27,12 @@ coap_get(_ChId, _Port, _Prefix, [], Query, _Request) ->
 coap_get(_ChId, _Port,  _Prefix, _Else, _Query, _Request) ->
     {error, not_found}.
 
-coap_post(_ChId, _Prefix, _Suffix, _Content, _Request) -> {error, method_not_allowed}.
-coap_put(_ChId, _Prefix, _Suffix, _Content, _Request) -> {error, method_not_allowed}.
-coap_delete(_ChId, _Prefix, _Suffix, _Request) -> {error, method_not_allowed}.
+coap_post(_ChId, _Port, _Prefix, _Suffix, _Content, _Request) -> {error, method_not_allowed}.
+coap_put(_ChId, _Port, _Prefix, _Suffix, _Content, _Request) -> {error, method_not_allowed}.
+coap_delete(_ChId, _Port, _Prefix, _Suffix, _Request) -> {error, method_not_allowed}.
 
-coap_observe(_ChId, _Prefix, _Suffix, _Ack, _Request) -> {error, method_not_allowed}.
-coap_unobserve(_State) -> ok.
+coap_observe(_ChId, _Port, _Prefix, _Suffix, _Ack, _Request) -> {error, method_not_allowed}.
+coap_unobserve(_Port, _State) -> ok.
 handle_info(_Message, State) -> {noreply, State}.
 coap_ack(_Ref, State) -> {ok, State}.
 

--- a/src/coap_transport.erl
+++ b/src/coap_transport.erl
@@ -11,7 +11,7 @@
 % handles message retransmission and de-duplication
 -module(coap_transport).
 
--export([init/6, received/3, send/2, timeout/2, awaits_response/1]).
+-export([init/6, received/2, send/2, timeout/2, awaits_response/1]).
 -export([idle/2, got_non/2, sent_non/2, got_rst/2, await_aack/2, pack_sent/2, await_pack/2, aack_sent/2]).
 
 -define(ACK_TIMEOUT, 2000).
@@ -29,7 +29,7 @@
 init(Sock, ChId, Channel, TrId, ReSup, Receiver) ->
     #state{phase=idle, sock=Sock, cid=ChId, channel=Channel, tid=TrId, resp=ReSup, receiver=Receiver}.
 % process incoming message
-received(ListenPort, BinMessage, State=#state{phase=Phase}) ->
+received(BinMessage, State=#state{phase=Phase}) ->
     ?MODULE:Phase({in, BinMessage}, State).
 % process outgoing message
 send(Message, State=#state{phase=Phase}) ->

--- a/src/coap_transport.erl
+++ b/src/coap_transport.erl
@@ -48,12 +48,10 @@ awaits_response(_State) ->
 
 % ->NON
 idle(Msg={in, <<1:2, 1:2, _:12, _Tail/bytes>>}, State=#state{channel=Channel, tid=TrId}) ->
-    error_logger:info_msg("_GREG_ coap transport got in non"),
     timeout_after(?NON_LIFETIME, Channel, TrId, transport),
     in_non(Msg, State);
 % ->CON
 idle(Msg={in, <<1:2, 0:2, _:12, _Tail/bytes>>}, State=#state{channel=Channel, tid=TrId}) ->
-    error_logger:info_msg("_GREG_ coap transport got in con"),
     timeout_after(?EXCHANGE_LIFETIME, Channel, TrId, transport),
     in_con(Msg, State);
 % NON->
@@ -68,7 +66,6 @@ idle(Msg={out, #coap_message{type=con}}, State=#state{channel=Channel, tid=TrId}
 % --- incoming NON
 
 in_non({in, BinMessage}, State) ->
-    error_logger:info_msg("_GREG_ coap transport non on port ~p", [State#state.port]),
     case catch coap_message_parser:decode(BinMessage) of
         #coap_message{method=Method} = Message when is_atom(Method) ->
             handle_request(Message, State);
@@ -81,7 +78,6 @@ in_non({in, BinMessage}, State) ->
     next_state(got_non, State).
 
 got_non({in, _Message}, State) ->
-    error_logger:info_msg("_GREG_ coap transport got non on port ~p", [State#state.port]),
     % ignore request retransmission
     next_state(got_non, State).
 
@@ -107,7 +103,6 @@ got_rst({in, _BinMessage}, State)->
 % --- incoming CON->ACK|RST
 
 in_con({in, BinMessage}, State) ->
-    error_logger:info_msg("_GREG_ coap transport con on port ~p", [State#state.port]),
     case catch coap_message_parser:decode(BinMessage) of
         #coap_message{method=undefined, id=MsgId} ->
             % provoked reset

--- a/src/coap_transport.erl
+++ b/src/coap_transport.erl
@@ -11,7 +11,7 @@
 % handles message retransmission and de-duplication
 -module(coap_transport).
 
--export([init/6, received/2, send/2, timeout/2, awaits_response/1]).
+-export([init/7, received/2, send/2, timeout/2, awaits_response/1]).
 -export([idle/2, got_non/2, sent_non/2, got_rst/2, await_aack/2, pack_sent/2, await_pack/2, aack_sent/2]).
 
 -define(ACK_TIMEOUT, 2000).
@@ -22,12 +22,12 @@
 -define(EXCHANGE_LIFETIME, 247000).
 -define(NON_LIFETIME, 145000).
 
--record(state, {phase, sock, cid, channel, tid, resp, receiver, msg, timer, retry_time, retry_count}).
+-record(state, {phase, sock, cid, channel, tid, resp, receiver, msg, timer, retry_time, retry_count, port}).
 
 -include("coap.hrl").
 
-init(Sock, ChId, Channel, TrId, ReSup, Receiver) ->
-    #state{phase=idle, sock=Sock, cid=ChId, channel=Channel, tid=TrId, resp=ReSup, receiver=Receiver}.
+init(Sock, ListenPort, ChId, Channel, TrId, ReSup, Receiver) ->
+    #state{phase=idle, sock=Sock, cid=ChId, channel=Channel, tid=TrId, resp=ReSup, receiver=Receiver, port=ListenPort}.
 % process incoming message
 received(BinMessage, State=#state{phase=Phase}) ->
     ?MODULE:Phase({in, BinMessage}, State).
@@ -68,7 +68,7 @@ idle(Msg={out, #coap_message{type=con}}, State=#state{channel=Channel, tid=TrId}
 % --- incoming NON
 
 in_non({in, BinMessage}, State) ->
-    error_logger:info_msg("_GREG_ in non"),
+    error_logger:info_msg("_GREG_ coap transport non on port ~p", [State#state.port]),
     case catch coap_message_parser:decode(BinMessage) of
         #coap_message{method=Method} = Message when is_atom(Method) ->
             handle_request(Message, State);
@@ -81,7 +81,7 @@ in_non({in, BinMessage}, State) ->
     next_state(got_non, State).
 
 got_non({in, _Message}, State) ->
-    error_logger:info_msg("_GREG_ coap transport got non"),
+    error_logger:info_msg("_GREG_ coap transport got non on port ~p", [State#state.port]),
     % ignore request retransmission
     next_state(got_non, State).
 
@@ -107,7 +107,7 @@ got_rst({in, _BinMessage}, State)->
 % --- incoming CON->ACK|RST
 
 in_con({in, BinMessage}, State) ->
-    error_logger:info_msg("_GREG_ in con"),
+    error_logger:info_msg("_GREG_ coap transport con on port ~p", [State#state.port]),
     case catch coap_message_parser:decode(BinMessage) of
         #coap_message{method=undefined, id=MsgId} ->
             % provoked reset
@@ -197,9 +197,9 @@ aack_sent({in, _Ack}, State) ->
 timeout_after(Time, Channel, TrId, Event) ->
     erlang:send_after(Time, Channel, {timeout, TrId, Event}).
 
-handle_request(Message, #state{cid=ChId, channel=Channel, resp=ReSup, receiver=undefined}) ->
+handle_request(Message, #state{port=ListenPort, cid=ChId, channel=Channel, resp=ReSup, receiver=undefined}) ->
     %io:fwrite("~p => ~p~n", [self(), Message]),
-    case coap_responder_sup:get_responder(ReSup, Message) of
+    case coap_responder_sup:get_responder(ReSup, Message, ListenPort) of
         {ok, Pid} ->
             Pid ! {coap_request, ChId, Channel, undefined, Message},
             ok;

--- a/src/coap_udp_socket.erl
+++ b/src/coap_udp_socket.erl
@@ -84,7 +84,7 @@ handle_info({udp, Socket, PeerIP, PeerPortNo, Data}, State=#state{port=ListenPor
         % channel found in cache
         {ok, Pid} ->
             error_logger:info_msg("_GREG_ ~p found channel ~p for ~p", [self(), Pid, ChId]),
-            Pid ! {datagram, {ListenPort, Data}},
+            Pid ! {datagram, Data},
             {noreply, State};
         undefined when is_pid(PoolPid) ->
             error_logger:info_msg("_GREG_ ~p did not found channel for ~p", [self(), ChId]),
@@ -92,7 +92,7 @@ handle_info({udp, Socket, PeerIP, PeerPortNo, Data}, State=#state{port=ListenPor
                 % new channel created
                 {ok, _, Pid} ->
                     error_logger:info_msg("_GREG_ ~p CREATED NEW channel ~p for ~p", [self(), Pid, ChId]),
-                    Pid ! {datagram, {ListenPort, Data}},
+                    Pid ! {datagram, Data},
                     {noreply, store_channel(ChId, Pid, State)};
                 % drop this packet
                 {error, _} ->

--- a/src/coap_udp_socket.erl
+++ b/src/coap_udp_socket.erl
@@ -99,9 +99,10 @@ handle_info({udp, Socket, PeerIP, PeerPortNo, Data}, State=#state{chans=Chans, p
 handle_info({datagram, {PeerIP, PeerPortNo}, Data}, State=#state{sock=Socket}) ->
     ok = gen_udp:send(Socket, PeerIP, PeerPortNo, Data),
     {noreply, State};
-handle_info({terminated, SupPid, ChId}, State=#state{chans=Chans}) ->
+handle_info({terminated, SupPid, ChId}, State=#state{chans=Chans, pool = PoolId}) ->
     Chans2 = dict:erase(ChId, Chans),
-    exit(SupPid, normal),
+%%    exit(SupPid, normal),
+    coap_channel_sup_sup:delete_channel(PoolId, ChId),
     {noreply, State#state{chans=Chans2}};
 handle_info(Info, State) ->
     io:fwrite("coap_udp_socket unexpected ~p~n", [Info]),


### PR DESCRIPTION
* Channels incoming to different UDP ports are differentiated (the listening port is the part of channel's process id)
  * The listening port is part of the state of all the channel's children
  * The resource callbacks receive the listening port as one of the parameters, so the module providing the resource servicing can route them appropriately
* Outgoing UDP port number can be specified for the client